### PR TITLE
Add armv7 support and remove nginx from Dockerfile

### DIFF
--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -8,10 +8,9 @@ COPY rootfs /
 # Setup base
 RUN apk add --no-cache \
     coreutils \
+    nginx \
     transmission-daemon \
     openvpn
-RUN apk add --no-cache \
-    nginx=1.14.2-r4
 # Small hack needed for ingress support
 #
 # Transmission always uses "transmission" as a subdirectory in the URL, so the web interface can for instance be found at:

--- a/transmission/build.json
+++ b/transmission/build.json
@@ -4,6 +4,7 @@
         "aarch64": "hassioaddons/base-aarch64:3.1.0",
         "amd64": "hassioaddons/base-amd64:3.1.0",
         "armhf": "hassioaddons/base-armhf:3.1.0",
+        "armv7": "hassioaddons/base-armv7:3.1.0",
         "i386": "hassioaddons/base-i386:3.1.0"
     },
     "args": {}

--- a/transmission/config.json
+++ b/transmission/config.json
@@ -9,12 +9,7 @@
     "ingress": "true",
     "ingress_port": 8099,
     "panel_icon": "mdi:progress-download",
-    "arch": [
-        "aarch64",
-        "amd64",
-        "armhf",
-        "i386"
-    ],
+    "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
     "map": [
       "config:rw",
       "share:rw",


### PR DESCRIPTION
Closes #5

This PR make `hassio-addon-transmission` work again with `armv7` support.

The only issue i couldn't find a solution to is that the addon seems to have still problems with the installation but it is not true. Leaving addon page and re-entering from Hass.io section shows the addon installed.