### PR TITLE
Add mapping to R/W in 'media' folder

### DIFF
--- a/transmission/config.json
+++ b/transmission/config.json
@@ -12,6 +12,7 @@
     "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
     "map": [
       "config:rw",
+      "media:rw",
       "share:rw",
       "ssl"
     ],


### PR DESCRIPTION
Minor addition. Changes no default configs, enables downloading to the 'media' folder.