### PR TITLE
Update add-on configuration for Supervisor 2021.2

### DIFF
--- a/transmission/config.json
+++ b/transmission/config.json
@@ -31,7 +31,7 @@
       "NET_ADMIN"
     ],
     "devices": [
-      "/dev/net/tun:/dev/net/tun:rwm"
+      "/dev/net/tun"
     ],
     "hassio_api": true,
     "homeassistant_api": false,


### PR DESCRIPTION
Add-on config 'devices' use a deprecated format, the new format uses a list of paths only.