### PR TITLE
fix #18 - openvpn fails to start

### DIFF
--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base:8.0.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:10.1.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/transmission/build.json
+++ b/transmission/build.json
@@ -1,11 +1,11 @@
 {
     "squash": false,
     "build_from": {
-        "aarch64": "hassioaddons/base-aarch64:8.0.1",
-        "amd64": "hassioaddons/base-amd64:8.0.1",
-        "armhf": "hassioaddons/base-armhf:8.0.1",
-        "armv7": "hassioaddons/base-armv7:8.0.1",
-        "i386": "hassioaddons/base-i386:8.0.1"
+        "aarch64": "ghcr.io/hassio-addons/base/aarch64:10.1.0",
+        "amd64": "ghcr.io/hassio-addons/base/amd64:10.1.0",
+        "armhf": "ghcr.io/hassio-addons/base/armhf:10.1.0",
+        "armv7": "ghcr.io/hassio-addons/base/armv7:10.1.0",
+        "i386": "ghcr.io/hassio-addons/base/i386:10.1.0"
     },
     "args": {}
 }

--- a/transmission/rootfs/etc/cont-init.d/10-requirements.sh
+++ b/transmission/rootfs/etc/cont-init.d/10-requirements.sh
@@ -6,25 +6,25 @@
 # Check authentication requirements, if enabled
 if bashio::config.true 'authentication_required'; then
     if ! bashio::config.has_value 'username'; then
-        bashio::die 'Transmission authentication is enabled, but no username was specified'
+        bashio::exit.nok 'Transmission authentication is enabled, but no username was specified'
     fi
 
     if ! bashio::config.has_value 'password'; then
-        bashio::die 'Transmission authentication is enabled, but no password was specified'
+        bashio::exit.nok 'Transmission authentication is enabled, but no password was specified'
     fi
 fi
 
 # Check OpenVPN requirements, if enabled
 if bashio::config.true 'openvpn_enabled'; then
     if ! bashio::config.has_value 'openvpn_username'; then
-        bashio::die 'OpenVPN is enabled, but no username was specified'
+        bashio::exit.nok 'OpenVPN is enabled, but no username was specified'
     fi
 
     if ! bashio::config.has_value 'openvpn_password'; then
-        bashio::die 'OpenVPN is enabled, but no password was specified'
+        bashio::exit.nok 'OpenVPN is enabled, but no password was specified'
     fi
 
-    if ! bashio::file_exists "/config/openvpn/$(bashio::config.get 'openvpn_config').ovpn"; then
-        bashio::die "The configured /config/openvpn/$(bashio::config.get 'openvpn_config').ovpn file is not found"
+    if ! bashio::fs.file_exists "/config/openvpn/$(bashio::config 'openvpn_config').ovpn"; then
+        bashio::exit.nok "The configured /config/openvpn/$(bashio::config 'openvpn_config').ovpn file is not found"
     fi
 fi


### PR DESCRIPTION
fix #18 - The configuraiton scripts that are being used when enabling OpenVPN are using old versions of the bashio functions.
I fixed the calls to the proper functions and also upgraded to the latest base image to gain all the performance they claim is better now