### PR TITLE
enable Incomplete/Downloads dirs configuration

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Transmission repository",
-  "url": "https://github.com/pierrickrouxel/hassio-addon-transmission",
+  "url": "https://github.com/pixeldublu/hassio-addon-transmission",
   "maintainer": "Pierrick Rouxel"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Transmission repository",
-  "url": "https://github.com/pixeldublu/hassio-addon-transmission",
+  "url": "https://github.com/pierrickrouxel/hassio-addon-transmission",
   "maintainer": "Pierrick Rouxel"
 }

--- a/transmission/config.json
+++ b/transmission/config.json
@@ -1,62 +1,66 @@
 {
-    "name": "Transmission",
-    "version": "dev",
-    "slug": "transmission",
-    "description": "The torrent client for Hass.io with OpenVPN support",
-    "url": "https://github.com/pierrickrouxel/hassio-addon-transmission",
-    "webui": "http://[HOST]:[PORT:9091]/transmission/web/",
-    "startup": "services",
-    "ingress": "true",
-    "ingress_port": 8099,
-    "panel_icon": "mdi:progress-download",
-    "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
-    "map": [
-      "config:rw",
-      "media:rw",
-      "share:rw",
-      "ssl"
-    ],
-    "boot": "auto",
-    "ports": {
-      "9091/tcp": null,
-      "51413/tcp": 51413,
-      "51413/udp": 51413
-    },
-   "ports_description": {
-      "9091/tcp": "Web UI port (Not required for Hass.io Ingress)",
-      "51413/tcp": "Peer port (setup port forwarding to this port)",
-      "51413/udp": "Peer port (setup port forwarding to this port)"
-    },
-    "privileged": [
-      "NET_ADMIN"
-    ],
-    "devices": [
-      "/dev/net/tun"
-    ],
-    "hassio_api": true,
-    "homeassistant_api": false,
-    "host_network": false,
-    "options": {
-      "log_level": "info",
-      "authentication_required": false,
-      "username": "",
-      "password": "",
-      "openvpn_enabled": false,
-      "openvpn_config": "",
-      "openvpn_username": "",
-      "openvpn_password": ""
-    },
-    "schema": {
-      "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)",
-      "authentication_required": "bool",
-      "username": "str",
-      "password": "str",
-      "openvpn_enabled": "bool",
-      "openvpn_config": "str",
-      "openvpn_username": "str",
-      "openvpn_password": "str"
-    },
-    "environment": {
-      "LOG_FORMAT": "{LEVEL}: {MESSAGE}"
-    }
+  "name": "Transmission",
+  "version": "dev",
+  "slug": "transmission",
+  "description": "The torrent client for Hass.io with OpenVPN support",
+  "url": "https://github.com/pierrickrouxel/hassio-addon-transmission",
+  "webui": "http://[HOST]:[PORT:9091]/transmission/web/",
+  "startup": "services",
+  "ingress": "true",
+  "ingress_port": 8099,
+  "panel_icon": "mdi:progress-download",
+  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "map": [
+    "config:rw",
+    "media:rw",
+    "share:rw",
+    "ssl"
+  ],
+  "boot": "auto",
+  "ports": {
+    "9091/tcp": null,
+    "51413/tcp": 51413,
+    "51413/udp": 51413
+  },
+ "ports_description": {
+    "9091/tcp": "Web UI port (Not required for Hass.io Ingress)",
+    "51413/tcp": "Peer port (setup port forwarding to this port)",
+    "51413/udp": "Peer port (setup port forwarding to this port)"
+  },
+  "privileged": [
+    "NET_ADMIN"
+  ],
+  "devices": [
+    "/dev/net/tun"
+  ],
+  "hassio_api": true,
+  "homeassistant_api": false,
+  "host_network": false,
+  "options": {
+    "log_level": "info",
+    "authentication_required": false,
+    "username": "",
+    "password": "",
+    "download_dir": "/share/downloads",
+    "incomplete_dir": "/share/incomplete",
+    "openvpn_enabled": false,
+    "openvpn_config": "",
+    "openvpn_username": "",
+    "openvpn_password": ""
+  },
+  "schema": {
+    "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)",
+    "authentication_required": "bool",
+    "username": "str",
+    "password": "str",
+    "download_dir": "match(^\/(share|media))",
+    "incomplete_dir": "match(^\/(share|media))",
+    "openvpn_enabled": "bool",
+    "openvpn_config": "str",
+    "openvpn_username": "str",
+    "openvpn_password": "str"
+  },
+  "environment": {
+    "LOG_FORMAT": "{LEVEL}: {MESSAGE}"
   }
+}

--- a/transmission/config.json
+++ b/transmission/config.json
@@ -1,66 +1,66 @@
 {
-  "name": "Transmission",
-  "version": "dev",
-  "slug": "transmission",
-  "description": "The torrent client for Hass.io with OpenVPN support",
-  "url": "https://github.com/pierrickrouxel/hassio-addon-transmission",
-  "webui": "http://[HOST]:[PORT:9091]/transmission/web/",
-  "startup": "services",
-  "ingress": "true",
-  "ingress_port": 8099,
-  "panel_icon": "mdi:progress-download",
-  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
-  "map": [
-    "config:rw",
-    "media:rw",
-    "share:rw",
-    "ssl"
-  ],
-  "boot": "auto",
-  "ports": {
-    "9091/tcp": null,
-    "51413/tcp": 51413,
-    "51413/udp": 51413
-  },
- "ports_description": {
-    "9091/tcp": "Web UI port (Not required for Hass.io Ingress)",
-    "51413/tcp": "Peer port (setup port forwarding to this port)",
-    "51413/udp": "Peer port (setup port forwarding to this port)"
-  },
-  "privileged": [
-    "NET_ADMIN"
-  ],
-  "devices": [
-    "/dev/net/tun"
-  ],
-  "hassio_api": true,
-  "homeassistant_api": false,
-  "host_network": false,
-  "options": {
-    "log_level": "info",
-    "authentication_required": false,
-    "username": "",
-    "password": "",
-    "download_dir": "/share/downloads",
-    "incomplete_dir": "/share/incomplete",
-    "openvpn_enabled": false,
-    "openvpn_config": "",
-    "openvpn_username": "",
-    "openvpn_password": ""
-  },
-  "schema": {
-    "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)",
-    "authentication_required": "bool",
-    "username": "str",
-    "password": "str",
-    "download_dir": "match(^\/(share|media))",
-    "incomplete_dir": "match(^\/(share|media))",
-    "openvpn_enabled": "bool",
-    "openvpn_config": "str",
-    "openvpn_username": "str",
-    "openvpn_password": "str"
-  },
-  "environment": {
-    "LOG_FORMAT": "{LEVEL}: {MESSAGE}"
+    "name": "Transmission",
+    "version": "dev",
+    "slug": "transmission",
+    "description": "The torrent client for Hass.io with OpenVPN support",
+    "url": "https://github.com/pierrickrouxel/hassio-addon-transmission",
+    "webui": "http://[HOST]:[PORT:9091]/transmission/web/",
+    "startup": "services",
+    "ingress": "true",
+    "ingress_port": 8099,
+    "panel_icon": "mdi:progress-download",
+    "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+    "map": [
+      "config:rw",
+      "media:rw",
+      "share:rw",
+      "ssl"
+    ],
+    "boot": "auto",
+    "ports": {
+      "9091/tcp": null,
+      "51413/tcp": 51413,
+      "51413/udp": 51413
+    },
+   "ports_description": {
+      "9091/tcp": "Web UI port (Not required for Hass.io Ingress)",
+      "51413/tcp": "Peer port (setup port forwarding to this port)",
+      "51413/udp": "Peer port (setup port forwarding to this port)"
+    },
+    "privileged": [
+      "NET_ADMIN"
+    ],
+    "devices": [
+      "/dev/net/tun"
+    ],
+    "hassio_api": true,
+    "homeassistant_api": false,
+    "host_network": false,
+    "options": {
+      "log_level": "info",
+      "authentication_required": false,
+      "username": "",
+      "password": "",
+      "download_dir": "/share/downloads",
+      "incomplete_dir": "/share/incomplete",
+      "openvpn_enabled": false,
+      "openvpn_config": "",
+      "openvpn_username": "",
+      "openvpn_password": ""
+    },
+    "schema": {
+      "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)",
+      "authentication_required": "bool",
+      "username": "str",
+      "password": "str",
+      "download_dir": "match(^\/(share|media))",
+      "incomplete_dir": "match(^\/(share|media))",
+      "openvpn_enabled": "bool",
+      "openvpn_config": "str",
+      "openvpn_username": "str",
+      "openvpn_password": "str"
+    },
+    "environment": {
+      "LOG_FORMAT": "{LEVEL}: {MESSAGE}"
+    }
   }
-}

--- a/transmission/rootfs/etc/cont-init.d/20-transmission-configuration.sh
+++ b/transmission/rootfs/etc/cont-init.d/20-transmission-configuration.sh
@@ -5,6 +5,8 @@ declare CONFIG
 declare authentication_required
 declare username
 declare password
+declare downloads_dir
+declare incomplete_dir
 
 if ! bashio::fs.directory_exists '/data/transmission'; then
   mkdir '/data/transmission'
@@ -17,9 +19,11 @@ fi
 CONFIG=$(</data/transmission/settings.json)
 
 # Defaults
-CONFIG=$(bashio::jq "${CONFIG}" ".\"incomplete-dir\"=\"/share/incomplete\"")
+incomplete_dir=$(bashio::config 'incomplete_dir')
+downloads_dir=$(bashio::config 'downloads_dir')
+CONFIG=$(bashio::jq "${CONFIG}" ".\"incomplete-dir\"=\"${incomplete_dir}\"")
 CONFIG=$(bashio::jq "${CONFIG}" ".\"incomplete-dir-enabled\"=true")
-CONFIG=$(bashio::jq "${CONFIG}" ".\"download-dir\"=\"/share/downloads\"")
+CONFIG=$(bashio::jq "${CONFIG}" ".\"download-dir\"=\"${downloads_dir}\"")
 CONFIG=$(bashio::jq "${CONFIG}" ".\"rpc-whitelist-enabled\"=false")
 CONFIG=$(bashio::jq "${CONFIG}" ".\"rpc-host-whitelist-enabled\"=false")
 CONFIG=$(bashio::jq "${CONFIG}" ".\"bind-address-ipv4\"=\"0.0.0.0\"")


### PR DESCRIPTION
Add option to configure downloads and incomplete dirs.  ( Also mentioned in #12 )

For example if you use an external drive and it is mapped inside /media/